### PR TITLE
feat: Market Sentiment Data Service

### DIFF
--- a/backend/app/services/sentiment_data.py
+++ b/backend/app/services/sentiment_data.py
@@ -1,0 +1,105 @@
+"""
+Market Sentiment Data Service.
+
+Mengambil indikator psikologi pasar dari berbagai sumber:
+1. Fear & Greed Index (alternative.me)
+2. Funding Rate (Exchange)
+3. Open Interest (Exchange)
+
+Usage:
+    sentiment = SentimentDataService(exchange_service)
+    score = await sentiment.get_composite_sentiment("BTC/USDT")
+"""
+
+import httpx
+from typing import Dict, Any, Optional
+from app.services.exchange import ExchangeService
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+class SentimentDataService:
+    """Service untuk agregasi sentimen pasar."""
+
+    def __init__(self, exchange: ExchangeService):
+        self.exchange = exchange
+        self.fear_greed_url = "https://api.alternative.me/fng/"
+        self.timeout = 10.0
+
+    async def get_fear_greed_index(self) -> Dict[str, Any]:
+        """Ambil Fear & Greed Index terbaru (0-100)."""
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(self.fear_greed_url)
+                if response.status_code == 200:
+                    data = response.json()
+                    fng = data.get("data", [{}])[0]
+                    logger.info("fear_greed_fetched", value=fng.get("value"), classification=fng.get("value_classification"))
+                    return {
+                        "value": int(fng.get("value", 50)),
+                        "classification": fng.get("value_classification", "Neutral")
+                    }
+                return {"value": 50, "classification": "Neutral"}
+        except Exception as e:
+            logger.error("fear_greed_fetch_failed", error=str(e))
+            return {"value": 50, "classification": "Neutral"}
+
+    async def get_exchange_sentiment(self, symbol: str) -> Dict[str, Any]:
+        """Ambil Funding Rate dan Open Interest dari exchange."""
+        try:
+            # Funding Rate
+            # Catatan: Tidak semua exchange mendukung fetch_funding_rate di CCXT standar
+            # Untuk futures/swap biasanya ada.
+            funding_rate = 0.0
+            try:
+                # CCXT unified method
+                fr_data = await self.exchange.exchange.fetch_funding_rate(symbol)
+                funding_rate = fr_data.get("fundingRate", 0.0)
+            except Exception:
+                # Fallback to fetch_tickers if funding rate is included there for some exchanges
+                pass
+
+            # Open Interest
+            open_interest = 0.0
+            try:
+                oi_data = await self.exchange.exchange.fetch_open_interest(symbol)
+                open_interest = oi_data.get("openInterestAmount", 0.0)
+            except Exception:
+                pass
+
+            logger.info("exchange_sentiment_fetched", symbol=symbol, funding_rate=funding_rate)
+            return {
+                "funding_rate": funding_rate,
+                "open_interest": open_interest
+            }
+        except Exception as e:
+            logger.error("exchange_sentiment_error", symbol=symbol, error=str(e))
+            return {"funding_rate": 0.0, "open_interest": 0.0}
+
+    async def get_composite_sentiment(self, symbol: str) -> Dict[str, Any]:
+        """Hitung skor sentimen gabungan dari -100 ke 100."""
+        fng = await self.get_fear_greed_index()
+        exc = await self.get_exchange_sentiment(symbol)
+        
+        # 1. Fear & Greed Score: (value - 50) * 2 -> Range -100 to 100
+        # 50 is neutral, 0 is extreme fear (-100), 100 is extreme greed (100)
+        fng_score = (fng["value"] - 50) * 2
+        
+        # 2. Funding Rate Score: Biasa berkisar -0.1% s/d 0.1%
+        # Positif Tinggi (> 0.03%) = Greed (Overleveraged Longs)
+        # Negatif Tinggi (< -0.03%) = Fear (Overleveraged Shorts)
+        fr_score = exc["funding_rate"] * 10000 / 3 # Scaling approx
+        fr_score = max(min(fr_score, 100), -100)
+        
+        # Composite: 70% F&G, 30% Exchange Sentiment (Bisa diadjust)
+        composite_score = (fng_score * 0.7) + (fr_score * 0.3)
+        
+        result = {
+            "symbol": symbol,
+            "composite_score": round(composite_score, 2),
+            "fear_greed": fng,
+            "exchange": exc
+        }
+        
+        logger.info("composite_sentiment_calculated", symbol=symbol, score=result["composite_score"])
+        return result

--- a/backend/tests/test_sentiment_data.py
+++ b/backend/tests/test_sentiment_data.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from app.services.sentiment_data import SentimentDataService
+
+@pytest.fixture
+def mock_exchange_service():
+    service = MagicMock()
+    service.exchange = AsyncMock()
+    return service
+
+@pytest.mark.asyncio
+async def test_get_fear_greed_index_success():
+    """Test fetching Fear & Greed Index successfully."""
+    service = SentimentDataService(exchange=None)
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [{"value": "75", "value_classification": "Greed"}]
+    }
+    
+    with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response
+        
+        result = await service.get_fear_greed_index()
+        
+        assert result["value"] == 75
+        assert result["classification"] == "Greed"
+
+@pytest.mark.asyncio
+async def test_get_exchange_sentiment_success(mock_exchange_service):
+    """Test fetching funding rate and open interest from exchange."""
+    service = SentimentDataService(exchange=mock_exchange_service)
+    
+    mock_exchange_service.exchange.fetch_funding_rate.return_value = {"fundingRate": 0.0001}
+    mock_exchange_service.exchange.fetch_open_interest.return_value = {"openInterestAmount": 1000000.0}
+    
+    result = await service.get_exchange_sentiment("BTC/USDT")
+    
+    assert result["funding_rate"] == 0.0001
+    assert result["open_interest"] == 1000000.0
+
+@pytest.mark.asyncio
+async def test_composite_sentiment_calculation(mock_exchange_service):
+    """Test the composite score calculation logic."""
+    service = SentimentDataService(exchange=mock_exchange_service)
+    
+    with patch.object(service, 'get_fear_greed_index', new_callable=AsyncMock) as mock_fng, \
+         patch.object(service, 'get_exchange_sentiment', new_callable=AsyncMock) as mock_exc:
+        
+        # Scenario: Greed (75) and High Positive Funding Rate (0.001)
+        mock_fng.return_value = {"value": 75, "classification": "Greed"}
+        mock_exc.return_value = {"funding_rate": 0.001, "open_interest": 0.0}
+        
+        result = await service.get_composite_sentiment("BTC/USDT")
+        
+        # F&G Score: (75-50)*2 = 50
+        # FR Score: (0.001*10000)/3 = 3.33
+        # Composite: 50*0.7 + 3.33*0.3 = 35 + 1 = 36
+        assert result["composite_score"] > 0
+        assert result["composite_score"] == 36.0 # (50*0.7) + (3.33*0.3) = 35 + 0.999 = 36.00


### PR DESCRIPTION
This PR implements task T-3.6: Service Pengambilan Sentimen Pasar.

It includes:
- : Aggregating sentiment from alternative.me (Fear & Greed) and Exchange (Funding Rate, Open Interest).
- Composite scoring logic to provide a unified market mood indicator.
- Integration with CCXT futures data for advanced sentiment metrics.
- Unit tests for validation of aggregation and scoring logic.