### PR TITLE
refactor: Migrasi On-Chain Data ke Free API Providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,14 +25,13 @@ EXCHANGE_API_SECRET=
 # Set to true for Testnet / Paper Trading (highly recommended for dev)
 EXCHANGE_TESTNET=true
 
-# === On-Chain Data ===
-# Get Whale Alert API Key at https://whale-alert.io/
-WHALE_ALERT_API_KEY=
-# Get Glassnode API Key at https://glassnode.com/
-GLASSNODE_API_KEY=
-# Get CryptoQuant API Key at https://cryptoquant.com/
-CRYPTOQUANT_API_KEY=
-# Get CryptoPanic API Key at https://cryptopanic.com/developers/api/
+# === On-Chain Data (Free Providers) ===
+# CoinGecko: Opsional, meningkatkan rate limit. Daftar di https://www.coingecko.com/en/api
+COINGECKO_API_KEY=
+# Etherscan: Free tier 5 req/detik. Daftar di https://etherscan.io/apis
+ETHERSCAN_API_KEY=
+# Blockchain.com: Tidak perlu API key (public API)
+# CryptoPanic: Daftar di https://cryptopanic.com/developers/api/
 CRYPTOPANIC_API_KEY=
 
 # === Database & Infrastructure ===

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -28,10 +28,9 @@ class Settings(BaseSettings):
     EXCHANGE_API_SECRET: str = ""
     EXCHANGE_TESTNET: bool = True  # True = paper trading (aman)
 
-    # === On-Chain Data ===
-    WHALE_ALERT_API_KEY: str = ""
-    GLASSNODE_API_KEY: str = ""
-    CRYPTOQUANT_API_KEY: str = ""
+    # === On-Chain Data (Free Providers) ===
+    COINGECKO_API_KEY: str = ""  # Opsional, meningkatkan rate limit
+    ETHERSCAN_API_KEY: str = ""  # Free tier: 5 req/detik, daftar di etherscan.io
     CRYPTOPANIC_API_KEY: str = ""
 
     # === Database ===

--- a/backend/app/services/onchain_data.py
+++ b/backend/app/services/onchain_data.py
@@ -1,13 +1,16 @@
 """
-On-Chain Data Service.
+On-Chain Data Service (Free Providers).
 
-Mengambil data dari blockchain via API pihak ketiga (WhaleAlert, Glassnode, CryptoQuant).
-Digunakan untuk analisa fundamental dan deteksi pergerakan uang besar (whale).
+Mengambil data blockchain dan market metrics menggunakan API gratis:
+1. CoinGecko — Market metrics, trending, global data
+2. Blockchain.com — BTC on-chain stats (tanpa API key)
+3. Etherscan — ETH whale tracking, large transfers (free tier)
 
 Usage:
     onchain = OnChainDataService()
-    whales = await onchain.get_whale_movements()
-    flows = await onchain.get_exchange_flows("BTC")
+    btc_stats = await onchain.get_btc_onchain_stats()
+    eth_whales = await onchain.get_eth_large_transfers()
+    summary = await onchain.get_summary("BTC")
 """
 
 import httpx
@@ -19,116 +22,264 @@ from app.schemas.market_data import NormalizedSentiment
 
 logger = get_logger(__name__)
 
+
 class OnChainDataService:
-    """Service untuk mengambil data metrik blockchain."""
+    """Service untuk mengambil data metrik blockchain dari provider gratis."""
 
     def __init__(self):
-        self.whale_key = settings.WHALE_ALERT_API_KEY
-        self.glassnode_key = settings.GLASSNODE_API_KEY
-        self.cryptoquant_key = settings.CRYPTOQUANT_API_KEY
+        self.coingecko_key = settings.COINGECKO_API_KEY
+        self.etherscan_key = settings.ETHERSCAN_API_KEY
         self.timeout = 10.0
 
-    async def get_whale_movements(self, min_value_usd: int = 500000) -> List[Dict[str, Any]]:
+        # Base URLs
+        self.coingecko_url = "https://api.coingecko.com/api/v3"
+        self.blockchain_url = "https://api.blockchain.info"
+        self.etherscan_url = "https://api.etherscan.io/api"
+
+    # ─── CoinGecko: Market Metrics ─────────────────────────────────────
+
+    async def get_global_market(self) -> Dict[str, Any]:
         """
-        Ambil transaksi besar (whale) terbaru.
-        
-        Args:
-            min_value_usd: Batas minimal nilai transaksi yang dianggap whale.
+        Ambil global market metrics dari CoinGecko.
+        Contoh: total market cap, volume 24h, BTC dominance.
         """
-        if not self.whale_key:
-            logger.warning("whale_alert_api_key_missing")
+        url = f"{self.coingecko_url}/global"
+        headers = {}
+        if self.coingecko_key:
+            headers["x-cg-demo-api-key"] = self.coingecko_key
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(url, headers=headers)
+                if response.status_code == 200:
+                    data = response.json().get("data", {})
+                    result = {
+                        "total_market_cap_usd": data.get("total_market_cap", {}).get("usd", 0),
+                        "total_volume_24h_usd": data.get("total_volume", {}).get("usd", 0),
+                        "btc_dominance": data.get("market_cap_percentage", {}).get("btc", 0),
+                        "active_cryptocurrencies": data.get("active_cryptocurrencies", 0),
+                        "market_cap_change_24h_pct": data.get("market_cap_change_percentage_24h_usd", 0),
+                    }
+                    logger.info("coingecko_global_fetched", btc_dominance=result["btc_dominance"])
+                    return result
+                else:
+                    logger.error("coingecko_global_error", status=response.status_code)
+                    return {}
+        except Exception as e:
+            logger.error("coingecko_global_failed", error=str(e))
+            return {}
+
+    async def get_trending_coins(self) -> List[Dict[str, Any]]:
+        """Ambil daftar coin yang sedang trending dari CoinGecko."""
+        url = f"{self.coingecko_url}/search/trending"
+        headers = {}
+        if self.coingecko_key:
+            headers["x-cg-demo-api-key"] = self.coingecko_key
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(url, headers=headers)
+                if response.status_code == 200:
+                    coins = response.json().get("coins", [])
+                    result = []
+                    for coin in coins:
+                        item = coin.get("item", {})
+                        result.append({
+                            "name": item.get("name"),
+                            "symbol": item.get("symbol"),
+                            "market_cap_rank": item.get("market_cap_rank"),
+                            "score": item.get("score"),
+                        })
+                    logger.info("coingecko_trending_fetched", count=len(result))
+                    return result
+                return []
+        except Exception as e:
+            logger.error("coingecko_trending_failed", error=str(e))
             return []
 
-        url = "https://api.whale-alert.io/v1/transactions"
-        params = {
-            "api_key": self.whale_key,
-            "min_value": min_value_usd,
+    # ─── Blockchain.com: BTC On-Chain Stats ────────────────────────────
+
+    async def get_btc_onchain_stats(self) -> Dict[str, Any]:
+        """
+        Ambil statistik on-chain BTC dari Blockchain.com (GRATIS, tanpa API key).
+        Data: hashrate, mempool size, avg block size, unconfirmed txs.
+        """
+        result = {
+            "hash_rate": 0,
+            "mempool_size": 0,
+            "avg_block_size": 0,
+            "unconfirmed_txs": 0,
+            "difficulty": 0,
         }
 
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
-                response = await client.get(url, params=params)
-                if response.status_code == 200:
-                    data = response.json()
-                    transactions = data.get("transactions", [])
-                    logger.info("whale_movements_fetched", count=len(transactions))
-                    return transactions
-                else:
-                    logger.error("whale_alert_api_error", status=response.status_code)
-                    return []
+                # Blockchain.com menyediakan endpoint stats mentah
+                stats_response = await client.get(f"{self.blockchain_url}/stats")
+                if stats_response.status_code == 200:
+                    data = stats_response.json()
+                    result.update({
+                        "hash_rate": data.get("hash_rate", 0),
+                        "avg_block_size": data.get("blocks_avg", 0),
+                        "difficulty": data.get("difficulty", 0),
+                        "n_blocks_total": data.get("n_blocks_total", 0),
+                        "minutes_between_blocks": data.get("minutes_between_blocks", 0),
+                    })
+
+                # Unconfirmed transaction count
+                unconf_response = await client.get(f"{self.blockchain_url}/q/unconfirmedcount")
+                if unconf_response.status_code == 200:
+                    result["unconfirmed_txs"] = int(unconf_response.text.strip())
+
+            logger.info("blockchain_stats_fetched", hash_rate=result["hash_rate"])
+            return result
+
         except Exception as e:
-            logger.error("whale_alert_fetch_failed", error=str(e))
+            logger.error("blockchain_stats_failed", error=str(e))
+            return result
+
+    # ─── Etherscan: ETH Large Transfers ────────────────────────────────
+
+    async def get_eth_large_transfers(self, min_value_eth: float = 100.0) -> List[Dict[str, Any]]:
+        """
+        Ambil transfer ETH besar terbaru dari Etherscan (free tier).
+        Menggunakan internal transaction list dari block terbaru.
+
+        Args:
+            min_value_eth: Minimal jumlah ETH yang dianggap whale transfer.
+        """
+        if not self.etherscan_key:
+            logger.warning("etherscan_api_key_missing")
             return []
 
-    async def get_exchange_flows(self, symbol: str = "BTC") -> Dict[str, Any]:
-        """
-        Ambil aliran dana bursa (Inflow vs Outflow).
-        Menggunakan Glassnode sebagai primary, CryptoQuant sebagai fallback.
-        """
-        result = {"inflow": 0.0, "outflow": 0.0, "net_flow": 0.0, "provider": None}
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                # Ambil block terbaru
+                params = {
+                    "module": "proxy",
+                    "action": "eth_blockNumber",
+                    "apikey": self.etherscan_key,
+                }
+                block_response = await client.get(self.etherscan_url, params=params)
+                if block_response.status_code != 200:
+                    return []
 
-        # 1. Try Glassnode
-        if self.glassnode_key:
-            try:
-                # Contoh endpoint Glassnode untuk inflow (sangat simplified)
-                # Di produksi, kita akan butuh list endpoint yang benar sesuai dokumentasi mereka
-                url = f"https://api.glassnode.com/v1/metrics/exchange/net_flow_sum"
-                params = {"api_key": self.glassnode_key, "a": symbol.lower(), "i": "24h"}
-                
-                async with httpx.AsyncClient(timeout=self.timeout) as client:
-                    response = await client.get(url, params=params)
-                    if response.status_code == 200:
-                        data = response.json()
-                        # Glassnode return list of objects [ {t: timestamp, v: value} ]
-                        if data and len(data) > 0:
-                            net_flow = data[-1].get("v", 0.0)
-                            result.update({
-                                "net_flow": net_flow,
-                                "provider": "glassnode"
-                            })
-                            logger.info("exchange_flows_fetched", symbol=symbol, provider="glassnode")
-                            return result
-            except Exception as e:
-                logger.warning("glassnode_fetch_failed", error=str(e))
+                latest_block = block_response.json().get("result", "0x0")
 
-        # 2. Fallback to CryptoQuant (Jika Glassnode gagal atau key tidak ada)
-        if self.cryptoquant_key:
-            # Implementasi fallback ke CryptoQuant di sini jika perlu
-            pass
+                # Ambil transaksi dari block terbaru
+                tx_params = {
+                    "module": "proxy",
+                    "action": "eth_getBlockByNumber",
+                    "tag": latest_block,
+                    "boolean": "true",
+                    "apikey": self.etherscan_key,
+                }
+                tx_response = await client.get(self.etherscan_url, params=tx_params)
+                if tx_response.status_code != 200:
+                    return []
 
-        return result
+                block_data = tx_response.json().get("result", {})
+                transactions = block_data.get("transactions", [])
+
+                # Filter by value (ETH in Wei, 1 ETH = 10^18 Wei)
+                min_wei = int(min_value_eth * 10**18)
+                large_txs = []
+                for tx in transactions:
+                    value_hex = tx.get("value", "0x0")
+                    value_wei = int(value_hex, 16) if value_hex else 0
+                    if value_wei >= min_wei:
+                        large_txs.append({
+                            "hash": tx.get("hash"),
+                            "from": tx.get("from"),
+                            "to": tx.get("to"),
+                            "value_eth": value_wei / 10**18,
+                            "block": tx.get("blockNumber"),
+                        })
+
+                logger.info("etherscan_large_transfers_fetched", count=len(large_txs))
+                return large_txs
+
+        except Exception as e:
+            logger.error("etherscan_fetch_failed", error=str(e))
+            return []
+
+    # ─── Etherscan: Gas Tracker ────────────────────────────────────────
+
+    async def get_eth_gas_price(self) -> Dict[str, Any]:
+        """Ambil gas price ETH terkini dari Etherscan."""
+        if not self.etherscan_key:
+            return {"low": 0, "average": 0, "high": 0}
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                params = {
+                    "module": "gastracker",
+                    "action": "gasoracle",
+                    "apikey": self.etherscan_key,
+                }
+                response = await client.get(self.etherscan_url, params=params)
+                if response.status_code == 200:
+                    data = response.json().get("result", {})
+                    return {
+                        "low": float(data.get("SafeGasPrice", 0)),
+                        "average": float(data.get("ProposeGasPrice", 0)),
+                        "high": float(data.get("FastGasPrice", 0)),
+                    }
+                return {"low": 0, "average": 0, "high": 0}
+        except Exception as e:
+            logger.error("etherscan_gas_failed", error=str(e))
+            return {"low": 0, "average": 0, "high": 0}
+
+    # ─── Aggregated Summary ────────────────────────────────────────────
 
     async def get_summary(self, symbol: str = "BTC") -> NormalizedSentiment:
-        """Agregasi data on-chain untuk memberikan skor sentimen fundamental."""
-        flows = await self.get_exchange_flows(symbol)
-        whales = await self.get_whale_movements()
-        
-        # Logika scoring sederhana:
-        # Net flow positif (banyak masuk ke exchange) = Bearish
-        # Banyak whale transfer besar ke exchange = Bearish
-        # Banyak whale transfer keluar dari exchange = Bullish
-        
+        """
+        Agregasi data on-chain untuk memberikan skor sentimen fundamental.
+
+        Skor dihitung berdasarkan:
+        - BTC dominance trend (dari CoinGecko)
+        - Market cap change 24h (dari CoinGecko)
+        - BTC unconfirmed tx count (dari Blockchain.com - mempool congestion)
+        """
+        global_market = await self.get_global_market()
+        btc_stats = await self.get_btc_onchain_stats()
+
         sentiment_score = 0  # -100 (Bearish) to 100 (Bullish)
-        
-        if flows["net_flow"] > 0:
-            sentiment_score -= 20
-        elif flows["net_flow"] < 0:
-            sentiment_score += 20
-            
-        # Analisis whale (sementara hanya count)
-        whale_count = len(whales)
-        if whale_count > 10:
-            sentiment_score -= 10 # High activity can be volatile
-            
-        # Classify the sentiment
+
+        # 1. Market cap change 24h
+        mc_change = global_market.get("market_cap_change_24h_pct", 0)
+        if mc_change > 3:
+            sentiment_score += 25
+        elif mc_change > 0:
+            sentiment_score += 10
+        elif mc_change < -3:
+            sentiment_score -= 25
+        elif mc_change < 0:
+            sentiment_score -= 10
+
+        # 2. BTC Dominance > 50% = flight to safety (slightly bearish for alts)
+        btc_dom = global_market.get("btc_dominance", 50)
+        if btc_dom > 55:
+            sentiment_score -= 5  # Capital leaving alts
+        elif btc_dom < 40:
+            sentiment_score += 5  # Alt season
+
+        # 3. Mempool congestion (many unconfirmed txs = network busy = high demand)
+        unconfirmed = btc_stats.get("unconfirmed_txs", 0)
+        if unconfirmed > 100000:
+            sentiment_score += 10  # Network sangat sibuk
+        elif unconfirmed > 50000:
+            sentiment_score += 5
+
+        # Classify
         classification = "Neutral"
-        if sentiment_score <= -20:
-            classification = "Fear"
-        elif sentiment_score >= 20:
-            classification = "Greed"
-            
+        if sentiment_score >= 20:
+            classification = "Bullish"
+        elif sentiment_score <= -20:
+            classification = "Bearish"
+
         return NormalizedSentiment(
-            source="onchain_summary",
+            source="onchain_free",
             score=sentiment_score,
             classification=classification,
             timestamp=datetime.now()

--- a/backend/tests/test_onchain_data.py
+++ b/backend/tests/test_onchain_data.py
@@ -2,68 +2,115 @@ import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 from app.services.onchain_data import OnChainDataService
 
+
 @pytest.mark.asyncio
-async def test_get_whale_movements_success():
-    """Test fetching whale movements successfully with mocks."""
+async def test_get_global_market_success():
+    """Test fetching global market metrics from CoinGecko."""
     service = OnChainDataService()
-    service.whale_key = "test-key"
-    
+
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = {
-        "transactions": [
-            {"hash": "0x123", "amount": 1000, "symbol": "BTC", "value_usd": 60000000}
-        ]
+        "data": {
+            "total_market_cap": {"usd": 2500000000000},
+            "total_volume": {"usd": 100000000000},
+            "market_cap_percentage": {"btc": 52.5},
+            "active_cryptocurrencies": 15000,
+            "market_cap_change_percentage_24h_usd": 2.5,
+        }
     }
-    
+
     with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
         mock_get.return_value = mock_response
-        
-        result = await service.get_whale_movements()
-        
-        assert len(result) == 1
-        assert result[0]["symbol"] == "BTC"
-        mock_get.assert_called_once()
+
+        result = await service.get_global_market()
+
+        assert result["btc_dominance"] == 52.5
+        assert result["total_market_cap_usd"] == 2500000000000
+        assert result["market_cap_change_24h_pct"] == 2.5
+
 
 @pytest.mark.asyncio
-async def test_get_exchange_flows_glassnode_success():
-    """Test fetching exchange flows from Glassnode with mocks."""
+async def test_get_btc_onchain_stats_success():
+    """Test fetching BTC on-chain stats from Blockchain.com."""
     service = OnChainDataService()
-    service.glassnode_key = "test-key"
-    
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = [{"t": 12345678, "v": -500.5}] # Net outflow
-    
+
+    mock_stats = MagicMock()
+    mock_stats.status_code = 200
+    mock_stats.json.return_value = {
+        "hash_rate": 500000000,
+        "difficulty": 72000000000000,
+        "n_blocks_total": 850000,
+        "minutes_between_blocks": 9.5,
+    }
+
+    mock_unconf = MagicMock()
+    mock_unconf.status_code = 200
+    mock_unconf.text = "75000"
+
     with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
-        mock_get.return_value = mock_response
-        
-        result = await service.get_exchange_flows("BTC")
-        
-        assert result["net_flow"] == -500.5
-        assert result["provider"] == "glassnode"
+        mock_get.side_effect = [mock_stats, mock_unconf]
+
+        result = await service.get_btc_onchain_stats()
+
+        assert result["hash_rate"] == 500000000
+        assert result["unconfirmed_txs"] == 75000
+
 
 @pytest.mark.asyncio
-async def test_get_whale_movements_no_key():
-    """Test that it returns empty list if no API key is provided."""
+async def test_get_eth_large_transfers_no_key():
+    """Test that ETH transfers returns empty if no Etherscan key."""
     service = OnChainDataService()
-    service.whale_key = ""
-    
-    result = await service.get_whale_movements()
+    service.etherscan_key = ""
+
+    result = await service.get_eth_large_transfers()
     assert result == []
 
+
 @pytest.mark.asyncio
-async def test_onchain_summary_aggregation():
-    """Test the summary aggregation logic."""
+async def test_get_summary_aggregation():
+    """Test the summary aggregation logic using mocks."""
     service = OnChainDataService()
-    
-    with patch.object(service, 'get_exchange_flows', new_callable=AsyncMock) as mock_flows, \
-         patch.object(service, 'get_whale_movements', new_callable=AsyncMock) as mock_whales:
-        
-        mock_flows.return_value = {"net_flow": -1000, "provider": "test"} # Bullish
-        mock_whales.return_value = [] # Neutral
-        
+
+    with patch.object(service, 'get_global_market', new_callable=AsyncMock) as mock_global, \
+         patch.object(service, 'get_btc_onchain_stats', new_callable=AsyncMock) as mock_btc:
+
+        # Scenario: Market cap up 5%, BTC dom 52%, mempool busy
+        mock_global.return_value = {
+            "market_cap_change_24h_pct": 5.0,
+            "btc_dominance": 52.0,
+        }
+        mock_btc.return_value = {
+            "unconfirmed_txs": 120000,
+        }
+
         summary = await service.get_summary("BTC")
-        
-        assert summary.score > 0
-        assert summary.classification == "Greed"
+
+        # mc_change > 3 => +25, btc_dom 52 (40-55) => 0, unconf > 100k => +10
+        assert summary.score == 35
+        assert summary.classification == "Bullish"
+        assert summary.source == "onchain_free"
+
+
+@pytest.mark.asyncio
+async def test_get_trending_coins_success():
+    """Test fetching trending coins from CoinGecko."""
+    service = OnChainDataService()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "coins": [
+            {"item": {"name": "Bitcoin", "symbol": "BTC", "market_cap_rank": 1, "score": 0}},
+            {"item": {"name": "Ethereum", "symbol": "ETH", "market_cap_rank": 2, "score": 1}},
+        ]
+    }
+
+    with patch('httpx.AsyncClient.get', new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_response
+
+        result = await service.get_trending_coins()
+
+        assert len(result) == 2
+        assert result[0]["symbol"] == "BTC"
+        assert result[1]["name"] == "Ethereum"


### PR DESCRIPTION
Closes #143

## Perubahan

### Provider Baru (Gratis)
| Provider | Data | API Key Required? |
|---|---|---|
| **CoinGecko** | Global market metrics, trending coins | Opsional (meningkatkan rate limit) |
| **Blockchain.com** | BTC hashrate, mempool, difficulty | ❌ Tidak perlu |
| **Etherscan** | ETH large transfers, gas price | ✅ Free tier (5 req/detik) |

### Provider Dihapus (Berbayar)
- ~~WhaleAlert~~ → Diganti Etherscan
- ~~Glassnode~~ → Diganti CoinGecko + Blockchain.com
- ~~CryptoQuant~~ → Diganti CoinGecko

### File yang Dimodifikasi
- `backend/app/services/onchain_data.py` — Full rewrite
- `backend/app/core/config.py` — Ganti config keys
- `.env.example` — Update template
- `backend/tests/test_onchain_data.py` — Tests untuk provider baru

### Test Results
✅ **47 tests passed**, 0 failed